### PR TITLE
Fix POSIX port after nOS API change

### DIFF
--- a/src/port/POSIX/nOSPort.c
+++ b/src/port/POSIX/nOSPort.c
@@ -109,7 +109,7 @@ static void* _SysTick (void *arg)
         /* Simulate entry in interrupt */
         nOS_isrNestingCounter = 1;
 
-        nOS_Tick();
+        nOS_Tick(1);
 
         /* Simulate exit of interrupt */
         nOS_isrNestingCounter = 0;


### PR DESCRIPTION
The POSIX port makes a call to nOS_Tick() that now needs
an argument specifying the tick increment.