### PR TITLE
nOS_Timer improvement

### DIFF
--- a/inc/nOS.h
+++ b/inc/nOS.h
@@ -1219,6 +1219,7 @@ nOS_TickCounter     nOS_GetTickCount                    (void);
  *                                                                                                                    *
  **********************************************************************************************************************/
  #define nOS_MsToTicks(MS)      (nOS_TickCounter)(((uint32_t)(MS)+((1000UL/(uint32_t)NOS_CONFIG_TICKS_PER_SECOND)-1UL))/(1000UL/(uint32_t)NOS_CONFIG_TICKS_PER_SECOND))
+ #define nOS_TicksToMs(Tick)    (nOS_TickCounter)(((uint32_t)(Tick)*1000UL)+1UL)/NOS_CONFIG_TICKS_PER_SECOND
 #endif
 
 #if (NOS_CONFIG_SLEEP_ENABLE > 0)

--- a/src/nOSTimer.c
+++ b/src/nOSTimer.c
@@ -472,7 +472,7 @@ nOS_Error nOS_TimerRestart (nOS_Timer *timer, nOS_TimerCounter reload)
     if (timer == NULL) {
         err = NOS_E_INV_OBJ;
     }
-    else if (reload == 0) {
+    else if ((reload == 0) && (timer->state & NOS_TIMER_FREE_RUNNING) == NOS_TIMER_FREE_RUNNING) {
         err = NOS_E_INV_VAL;
     } else
 #endif


### PR DESCRIPTION
Add nOS_TicksToMs function
On nOS_TimerRestart function, the reload value can be equal to 0 when timer state is not in free running mode.
The timer will be kick right away when reload value equal 0.